### PR TITLE
Refactoring out static methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,103 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code related
+.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+**/.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+**/*.g.dart
+/build/
+
+
+.gradle/
+gradle*
+*.cer
+
+# Swagger
+.swagger-codegen-ignore
+.swagger-codegen/
+swagger-cli.jar
+**/docs
+
+# Android related
+**/android/.gradle
+**/android/captures/
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+**/android/**/key.jks
+**/android/**/google-services.json
+**/android/.gradletasknamecache
+**/android/release-manager-key.json
+
+# Fastlane
+fastlane/metadata/android/en-US/*.txt
+fastlane/report.xml
+fastlane/README.md
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/Flutter.podspec
+**/ios/**/xcuserdata
+**/ios/*.cer
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/fastlane/report.xml
+*.mobileprovision
+**/ios/.generated/
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+**/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+
+coverage/
+lib/generated/
+res/
+
+
+.direnv
+.aliases.sh
+
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -56,21 +56,37 @@ class Router {
           settings: settings,
         );
       case '/Home':
-        return GetRoute(
-            settings: settings, page: Home(), transition: Transition.fade);
+        return GetRoute(settings: settings, page: Home(), transition: Transition.fade);
       case '/Chat':
-        return GetRoute(
-            settings: settings,
-            page: Chat(),
-            transition: Transition.rightToLeft);
+        return GetRoute(settings: settings, page: Chat(), transition: Transition.rightToLeft);
       default:
         return GetRoute(
             settings: settings,
             transition: Transition.rotate,
             page: Scaffold(
-              body:
-                  Center(child: Text('No route defined for ${settings.name}')),
+              body: Center(child: Text('No route defined for ${settings.name}')),
             ));
     }
+  }
+}
+
+class SplashScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Text("Splash Screen"));
+  }
+}
+
+class Home extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Text("Home Page"));
+  }
+}
+
+class Chat extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Text("Chat"));
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,7 +62,7 @@ class Router {
       default:
         return GetRoute(
             settings: settings,
-            transition: Transition.rotate,
+            transition: Transition.fade,
             page: Scaffold(
               body: Center(child: Text('No route defined for ${settings.name}')),
             ));

--- a/lib/src/getroute.dart
+++ b/lib/src/getroute.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 class GetRoute<T> extends PageRouteBuilder<T> {
   /// Construct a Modified PageRoute whose contents are defined by child.
@@ -21,16 +22,13 @@ class GetRoute<T> extends PageRouteBuilder<T> {
         assert(opaque != null),
         super(
             fullscreenDialog: fullscreenDialog,
-            pageBuilder: (BuildContext context, Animation<double> animation,
-                Animation<double> secondaryAnimation) {
+            pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
               return page;
             },
             transitionDuration: duration,
             settings: settings,
-            transitionsBuilder: (BuildContext context,
-                Animation<double> animation,
-                Animation<double> secondaryAnimation,
-                Widget child) {
+            transitionsBuilder: (BuildContext context, Animation<double> animation,
+                Animation<double> secondaryAnimation, Widget child) {
               switch (transition) {
                 case Transition.fade:
                   return FadeTransition(opacity: animation, child: child);
@@ -179,6 +177,11 @@ class GetRoute<T> extends PageRouteBuilder<T> {
                   return FadeTransition(opacity: animation, child: child);
               }
             });
+
+  @override
+  NavigatorState get navigator {
+    return Get.key.currentState;
+  }
 
   @override
   final bool maintainState;

--- a/lib/src/getroute.dart
+++ b/lib/src/getroute.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 
 class GetRoute<T> extends PageRouteBuilder<T> {
   /// Construct a Modified PageRoute whose contents are defined by child.
@@ -177,11 +176,6 @@ class GetRoute<T> extends PageRouteBuilder<T> {
                   return FadeTransition(opacity: animation, child: child);
               }
             });
-
-  @override
-  NavigatorState get navigator {
-    return Get.key.currentState;
-  }
 
   @override
   final bool maintainState;

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -138,7 +138,7 @@ abstract class GetService {
 }
 
 class _Get implements GetService {
-  GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
+  final GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
 
   ///Use Get.to instead of Navigator.push, Get.off instead of Navigator.pushReplacement,
   ///Get.offAll instead of Navigator.pushAndRemoveUntil. For named routes just add "named"

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -1,12 +1,19 @@
 import 'package:flutter/material.dart';
+
 import 'bottomsheet.dart';
 import 'dialog.dart';
-import 'snack.dart';
 import 'getroute.dart';
+import 'snack.dart';
 
-class Get {
-  static Get _get;
-  static GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
+// ignore: non_constant_identifier_names
+final _Get Get = _Get._();
+
+abstract class GetService {
+  GlobalKey<NavigatorState> get key;
+}
+
+class _Get {
+  GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
 
   ///Use Get.to instead of Navigator.push, Get.off instead of Navigator.pushReplacement,
   ///Get.offAll instead of Navigator.pushAndRemoveUntil. For named routes just add "named"
@@ -14,9 +21,8 @@ class Get {
   ///To return to the previous screen, use Get.back().
   ///No need to pass any context to Get, just put the name of the route inside
   ///the parentheses and the magic will occur.
-  factory Get() {
-    if (_get == null) _get = Get._();
-    return _get;
+  factory _Get() {
+    return Get;
   }
 
   ///Use Get.to instead of Navigator.push, Get.off instead of Navigator.pushReplacement,
@@ -25,78 +31,75 @@ class Get {
   ///To return to the previous screen, use Get.back().
   ///No need to pass any context to Get, just put the name of the route inside
   ///the parentheses and the magic will occur.
-  Get._();
+  _Get._();
 
   /// It replaces Navigator.push, but needs no context, and it doesn't have the Navigator.push
   /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
   /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
-  static to(Widget page,
-      {bool rebuildRoutes = false, Transition transition = Transition.fade}) {
+  Future<T> to<T>(Widget page, {bool rebuildRoutes = false, Transition transition = Transition.fade}) {
     // if (key.currentState.mounted) // add this if appear problems on future with route navigate
     // when widget don't mounted
-    return key.currentState.push(
-        GetRoute(opaque: rebuildRoutes, page: page, transition: transition));
+    return key.currentState.push<T>(GetRoute(opaque: rebuildRoutes, page: page, transition: transition));
   }
 
   /// It replaces Navigator.pushNamed, but needs no context, and it doesn't have the Navigator.pushNamed
   /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
   /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
-  static toNamed(String page, {arguments}) {
+  Future<T> toNamed<T>(String page, {arguments}) {
     // if (key.currentState.mounted) // add this if appear problems on future with route navigate
     // when widget don't mounted
-    return key.currentState.pushNamed(page, arguments: arguments);
+    return key.currentState.pushNamed<T>(page, arguments: arguments);
   }
 
   /// It replaces Navigator.pushReplacementNamed, but needs no context.
-  static offNamed(String page, {arguments}) {
+  Future<T> offNamed<T, TO>(String page, {arguments}) {
     // if (key.currentState.mounted) // add this if appear problems on future with route navigate
     // when widget don't mounted
-    return key.currentState.pushReplacementNamed(page, arguments: arguments);
+    return key.currentState.pushReplacementNamed<T, TO>(page, arguments: arguments);
   }
 
   /// It replaces Navigator.popUntil, but needs no context.
-  static until(String page, predicate) {
+  void until(String page, predicate) {
     // if (key.currentState.mounted) // add this if appear problems on future with route navigate
     // when widget don't mounted
     return key.currentState.popUntil(predicate);
   }
 
   /// It replaces Navigator.pushAndRemoveUntil, but needs no context.
-  static offUntil(page, predicate) {
+  Future<T> offUntil<T>(page, predicate) {
     // if (key.currentState.mounted) // add this if appear problems on future with route navigate
     // when widget don't mounted
-    return key.currentState.pushAndRemoveUntil(page, predicate);
+    return key.currentState.pushAndRemoveUntil<T>(page, predicate);
   }
 
   /// It replaces Navigator.pushNamedAndRemoveUntil, but needs no context.
-  static offNamedUntil(page, predicate) {
+  Future<T> offNamedUntil<T>(page, predicate) {
     // if (key.currentState.mounted) // add this if appear problems on future with route navigate
     // when widget don't mounted
-    return key.currentState.pushNamedAndRemoveUntil(page, predicate);
+    return key.currentState.pushNamedAndRemoveUntil<T>(page, predicate);
   }
 
   /// It replaces Navigator.removeRoute, but needs no context.
-  static removeRoute(route) {
+  void removeRoute(route) {
     return key.currentState.removeRoute(route);
   }
 
   /// It replaces Navigator.pushNamedAndRemoveUntil, but needs no context.
-  static offAllNamed(
+  Future<T> offAllNamed<T>(
     String newRouteName,
     RoutePredicate predicate, {
     arguments,
   }) {
-    return key.currentState
-        .pushNamedAndRemoveUntil(newRouteName, predicate, arguments: arguments);
+    return key.currentState.pushNamedAndRemoveUntil<T>(newRouteName, predicate, arguments: arguments);
   }
 
   /// It replaces Navigator.pop, but needs no context.
-  static back({result}) {
-    return key.currentState.pop(result);
+  bool back<T>({T result}) {
+    return key.currentState.pop<T>(result);
   }
 
   /// It will close as many screens as you define. Times must be> 0;
-  static close(int times) {
+  void close(int times) {
     if ((times == null) || (times < 1)) {
       times = 1;
     }
@@ -110,24 +113,20 @@ class Get {
   /// It replaces Navigator.pushReplacement, but needs no context, and it doesn't have the Navigator.pushReplacement
   /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
   /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
-  static off(Widget page,
-      {bool rebuildRoutes = false,
-      Transition transition = Transition.rightToLeft}) {
-    return key.currentState.pushReplacement(
-        GetRoute(opaque: rebuildRoutes, page: page, transition: transition));
+  Future<T> off<T, TO>(Widget page, {bool rebuildRoutes = false, Transition transition = Transition.rightToLeft}) {
+    return key.currentState
+        .pushReplacement<T, TO>(GetRoute<T>(opaque: rebuildRoutes, page: page, transition: transition));
   }
 
   /// It replaces Navigator.pushAndRemoveUntil, but needs no context
-  static offAll(Widget page, RoutePredicate predicate,
-      {bool rebuildRoutes = false,
-      Transition transition = Transition.rightToLeft}) {
-    return key.currentState.pushAndRemoveUntil(
-        GetRoute(opaque: rebuildRoutes, page: page, transition: transition),
-        predicate);
+  Future<T> offAll<T>(Widget page, RoutePredicate predicate,
+      {bool rebuildRoutes = false, Transition transition = Transition.rightToLeft}) {
+    return key.currentState
+        .pushAndRemoveUntil<T>(GetRoute<T>(opaque: rebuildRoutes, page: page, transition: transition), predicate);
   }
 
   /// Show a dialog. You can choose color and opacity of background
-  static Future<T> dialog<T>(
+  Future<T> dialog<T>(
     Widget child, {
     bool barrierDismissible = true,
     //  WidgetBuilder builder,
@@ -135,23 +134,18 @@ class Get {
   }) {
     assert(child != null);
     assert(useRootNavigator != null);
-    final ThemeData theme =
-        Theme.of(Get.key.currentContext, shadowThemeOnly: true);
+    final ThemeData theme = Theme.of(key.currentContext, shadowThemeOnly: true);
     return getShowGeneralDialog(
-      pageBuilder: (BuildContext buildContext, Animation<double> animation,
-          Animation<double> secondaryAnimation) {
+      pageBuilder: (BuildContext buildContext, Animation<double> animation, Animation<double> secondaryAnimation) {
         final Widget pageChild = child; // ?? Builder(builder: builder);
         return SafeArea(
           child: Builder(builder: (BuildContext context) {
-            return theme != null
-                ? Theme(data: theme, child: pageChild)
-                : pageChild;
+            return theme != null ? Theme(data: theme, child: pageChild) : pageChild;
           }),
         );
       },
       barrierDismissible: barrierDismissible,
-      barrierLabel: MaterialLocalizations.of(Get.key.currentContext)
-          .modalBarrierDismissLabel,
+      barrierLabel: MaterialLocalizations.of(key.currentContext).modalBarrierDismissLabel,
       barrierColor: Colors.black54,
       transitionDuration: const Duration(milliseconds: 150),
       // transitionBuilder: _buildMaterialDialogTransitions,
@@ -159,7 +153,7 @@ class Get {
     );
   }
 
-  static defaultDialog(
+  Future defaultDialog(
       {Color color,
       double opacity = 0.2,
       String title = "Alert dialog",
@@ -175,10 +169,10 @@ class Get {
       confirm: confirm,
     );
 
-    dialog(child);
+    return dialog<dynamic>(child);
   }
 
-  static Future<T> bottomSheet<T>({
+  Future<T> bottomSheet<T>({
     @required WidgetBuilder builder,
     Color backgroundColor,
     double elevation,
@@ -196,12 +190,11 @@ class Get {
     assert(isDismissible != null);
     assert(enableDrag != null);
 
-    return Get.key.currentState.push<T>(GetModalBottomSheetRoute<T>(
+    return key.currentState.push<T>(GetModalBottomSheetRoute<T>(
       builder: builder,
-      theme: Theme.of(Get.key.currentContext, shadowThemeOnly: true),
+      theme: Theme.of(key.currentContext, shadowThemeOnly: true),
       isScrollControlled: isScrollControlled,
-      barrierLabel: MaterialLocalizations.of(Get.key.currentContext)
-          .modalBarrierDismissLabel,
+      barrierLabel: MaterialLocalizations.of(key.currentContext).modalBarrierDismissLabel,
       backgroundColor: backgroundColor,
       elevation: elevation,
       shape: shape,
@@ -212,7 +205,7 @@ class Get {
     ));
   }
 
-  static snackbar(title, message,
+  GetBar snackbar(title, message,
       {Color colorText,
       Duration duration,
       SnackPosition snackPosition,
@@ -252,8 +245,7 @@ class Get {
             Text(
               title,
               style: TextStyle(
-                  color:
-                      colorText ?? Theme.of(Get.key.currentContext).accentColor,
+                  color: colorText ?? Theme.of(Get.key.currentContext).accentColor,
                   fontWeight: FontWeight.w800,
                   fontSize: 16),
             ),
@@ -261,8 +253,7 @@ class Get {
             Text(
               message,
               style: TextStyle(
-                  color:
-                      colorText ?? Theme.of(Get.key.currentContext).accentColor,
+                  color: colorText ?? Theme.of(Get.key.currentContext).accentColor,
                   fontWeight: FontWeight.w300,
                   fontSize: 14),
             ),

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -6,13 +6,138 @@ import 'getroute.dart';
 import 'snack.dart';
 
 // ignore: non_constant_identifier_names
-final _Get Get = _Get._();
+final GetService Get = _Get();
 
+///Use Get.to instead of Navigator.push, Get.off instead of Navigator.pushReplacement,
+///Get.offAll instead of Navigator.pushAndRemoveUntil. For named routes just add "named"
+///after them. Example: Get.toNamed, Get.offNamed, and Get.AllNamed.
+///To return to the previous screen, use Get.back().
+///No need to pass any context to Get, just put the name of the route inside
+///the parentheses and the magic will occur.
 abstract class GetService {
   GlobalKey<NavigatorState> get key;
+
+  factory GetService() => Get;
+
+  /// It replaces Navigator.push, but needs no context, and it doesn't have the Navigator.push
+  /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
+  /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
+  Future<T> to<T>(Widget page, {bool rebuildRoutes = false, Transition transition = Transition.fade});
+
+  /// It replaces Navigator.pushNamed, but needs no context, and it doesn't have the Navigator.pushNamed
+  /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
+  /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
+  Future<T> toNamed<T>(String page, {arguments});
+
+  /// It replaces Navigator.pushReplacementNamed, but needs no context.
+  Future<T> offNamed<T, TO>(String page, {arguments});
+
+  /// It replaces Navigator.popUntil, but needs no context.
+  void until(String page, predicate);
+
+  /// It replaces Navigator.pushAndRemoveUntil, but needs no context.
+  Future<T> offUntil<T>(page, predicate);
+
+  /// It replaces Navigator.pushNamedAndRemoveUntil, but needs no context.
+  Future<T> offNamedUntil<T>(page, predicate);
+
+  /// It replaces Navigator.removeRoute, but needs no context.
+  void removeRoute(route);
+
+  /// It replaces Navigator.pushNamedAndRemoveUntil, but needs no context.
+  ///
+  /// If no [predicate] is provided, then all routes will be popped
+  Future<T> offAllNamed<T>(
+    String newRouteName, {
+    RoutePredicate predicate,
+    arguments,
+  });
+
+  /// It replaces Navigator.pop, but needs no context.
+  bool back<T>({T result});
+
+  /// It will close as many screens as you define. Times must be> 0;
+  void close(int times);
+
+  /// It replaces Navigator.pushReplacement, but needs no context, and it doesn't have the Navigator.pushReplacement
+  /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
+  /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
+  ///
+  /// If no [predicate] is provided, then all routes will be popped
+  Future<T> off<T, TO>(Widget page, {bool rebuildRoutes = false, Transition transition = Transition.rightToLeft});
+
+  /// It replaces Navigator.pushAndRemoveUntil, but needs no context
+  ///
+  /// If no [predicate] is provided, then all routes will be popped
+  Future<T> offAll<T>(Widget page,
+      {RoutePredicate predicate, bool rebuildRoutes = false, Transition transition = Transition.rightToLeft});
+
+  /// Show a dialog. You can choose color and opacity of background
+  Future<T> dialog<T>(
+    Widget child, {
+    bool barrierDismissible = true,
+    //  WidgetBuilder builder,
+    bool useRootNavigator = true,
+  });
+
+  Future defaultDialog(
+      {Color color,
+      double opacity = 0.2,
+      String title = "Alert dialog",
+      Widget content,
+      Widget cancel,
+      Widget confirm});
+
+  Future<T> bottomSheet<T>({
+    @required WidgetBuilder builder,
+    Color backgroundColor,
+    double elevation,
+    ShapeBorder shape,
+    Clip clipBehavior,
+    Color barrierColor,
+    bool isScrollControlled = false,
+    bool useRootNavigator = false,
+    bool isDismissible = true,
+    bool enableDrag = true,
+  });
+
+  GetBar snackbar(title, message,
+      {Color colorText,
+      Duration duration,
+      SnackPosition snackPosition,
+      Widget titleText,
+      Widget messageText,
+      Widget icon,
+      bool shouldIconPulse,
+      double maxWidth,
+      EdgeInsets margin,
+      EdgeInsets padding,
+      double borderRadius,
+      Color borderColor,
+      double borderWidth,
+      Color backgroundColor,
+      Color leftBarIndicatorColor,
+      List<BoxShadow> boxShadows,
+      Gradient backgroundGradient,
+      FlatButton mainButton,
+      OnTap onTap,
+      bool isDismissible,
+      bool showProgressIndicator,
+      SnackDismissDirection dismissDirection,
+      AnimationController progressIndicatorController,
+      Color progressIndicatorBackgroundColor,
+      Animation<Color> progressIndicatorValueColor,
+      SnackStyle snackStyle,
+      Curve forwardAnimationCurve,
+      Curve reverseAnimationCurve,
+      Duration animationDuration,
+      double barBlur,
+      double overlayBlur,
+      Color overlayColor,
+      Form userInputForm});
 }
 
-class _Get {
+class _Get implements GetService {
   GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
 
   ///Use Get.to instead of Navigator.push, Get.off instead of Navigator.pushReplacement,
@@ -21,17 +146,7 @@ class _Get {
   ///To return to the previous screen, use Get.back().
   ///No need to pass any context to Get, just put the name of the route inside
   ///the parentheses and the magic will occur.
-  factory _Get() {
-    return Get;
-  }
-
-  ///Use Get.to instead of Navigator.push, Get.off instead of Navigator.pushReplacement,
-  ///Get.offAll instead of Navigator.pushAndRemoveUntil. For named routes just add "named"
-  ///after them. Example: Get.toNamed, Get.offNamed, and Get.AllNamed.
-  ///To return to the previous screen, use Get.back().
-  ///No need to pass any context to Get, just put the name of the route inside
-  ///the parentheses and the magic will occur.
-  _Get._();
+  _Get();
 
   /// It replaces Navigator.push, but needs no context, and it doesn't have the Navigator.push
   /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
@@ -85,11 +200,14 @@ class _Get {
   }
 
   /// It replaces Navigator.pushNamedAndRemoveUntil, but needs no context.
+  ///
+  /// If no [predicate] is provided, then all routes will be popped
   Future<T> offAllNamed<T>(
-    String newRouteName,
-    RoutePredicate predicate, {
+    String newRouteName, {
+    RoutePredicate predicate,
     arguments,
   }) {
+    predicate ??= (route) => false;
     return key.currentState.pushNamedAndRemoveUntil<T>(newRouteName, predicate, arguments: arguments);
   }
 
@@ -113,14 +231,19 @@ class _Get {
   /// It replaces Navigator.pushReplacement, but needs no context, and it doesn't have the Navigator.pushReplacement
   /// routes rebuild bug present in Flutter. If for some strange reason you want the default behavior
   /// of rebuilding every app after a route, use rebuildRoutes = true as the parameter.
+  ///
+  /// If no [predicate] is provided, then all routes will be popped
   Future<T> off<T, TO>(Widget page, {bool rebuildRoutes = false, Transition transition = Transition.rightToLeft}) {
     return key.currentState
         .pushReplacement<T, TO>(GetRoute<T>(opaque: rebuildRoutes, page: page, transition: transition));
   }
 
   /// It replaces Navigator.pushAndRemoveUntil, but needs no context
-  Future<T> offAll<T>(Widget page, RoutePredicate predicate,
-      {bool rebuildRoutes = false, Transition transition = Transition.rightToLeft}) {
+  ///
+  /// If no [predicate] is provided, then all routes will be popped
+  Future<T> offAll<T>(Widget page,
+      {RoutePredicate predicate, bool rebuildRoutes = false, Transition transition = Transition.rightToLeft}) {
+    predicate ??= (route) => true;
     return key.currentState
         .pushAndRemoveUntil<T>(GetRoute<T>(opaque: rebuildRoutes, page: page, transition: transition), predicate);
   }


### PR DESCRIPTION
These changes fall in the personal preference gray area, but I'll try to make a case for them:

###  Convert static methods to instance methods, then use a static instance named `Get`

In this PR, I've created a public abstract class `GetService` that contains method definitions & documentation, and is the public face of the `Get` library.  Making a public interface allows consumers to create dart extension methods, which would be especially useful for a library like `Get`.  

```
/// Example extensions
extension GetExtensions on GetService {
  Future<Contact> editContact(String contactId) {
    return this.dialog<Contact>(ContactEditPage(contactId: contactId), barrierDismissable: true, 
            useRootNavigator: false);
  }

  Future<T> confirm<T>({String title, String subtitle, T onConfirm()}) async {
    if (await this.dialog<bool>(ConfirmDialog(title:title, subtitle:subtitle)) {
       return await onConfirm();
    }
  }
}

/// These extensions can be used side-by-side with other routing code:
final contact = await Get.confirm(title: "Are you sure?", onConfirm: ()=> Get.editContact(contactId));
```
You can't create extensions from a Type (static)

### Return types
The other change I made was to be explicit with return types.

```
dialog<T>(child) {...}

to 

Future<T> dialog<T>(child) {...}
```

### Override [navigator] for [GetRoute]

I was seeing a NPE because the `CupertinoPageRoute.buildTransitions` method was expecting the `Route.navigator` to be bound (which only happens on `push`.  Since we're storing the navigator key globally, we can make this property always available.

Anyhow, feel free to close this PR if these changes don't make sense.
