### PR TITLE
Fix isRegistered 'name' param

### DIFF
--- a/lib/src/get_main.dart
+++ b/lib/src/get_main.dart
@@ -692,7 +692,7 @@ class Get {
 
   /// Find a instance from required class
   static S find<S>({String name, _FcBuilderFunc<S> instance}) {
-    if (Get.isRegistred<S>()) {
+    if (Get.isRegistred<S>(name: name)) {
       String key = _getKey(S, name);
       _FcBuilder builder = Get()._singl[key];
       if (builder == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get
 description: Open screens/snackbars/dialogs/bottomSheets without context, manage states and inject dependencies easily with Get.
-version: 2.5.8
+version: 2.5.9
 homepage: https://github.com/jonataslaw/get
 
 environment:


### PR DESCRIPTION
Fixing an error when injecting two different objects of the same type using the "name" parameter.

**How to reproduce:**
```
void main() {
  Get.put<FakeDio>(ApiHelper.herokuApi, name: "1");
  Get.put<FakeDio>(ApiHelper.awsApi, name: "2");

  Get.put<FakeRemoteDataSource>(
      FakeRemoteDataSource(
          herokuApi: Get.find<FakeDio>(name: "1"),
          awsApi: Get.find<FakeDio>(name: "2")
      )
  );

  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return GetMaterialApp(
      title: 'Get Sample',
      theme: ThemeData(
        primarySwatch: Colors.blue,
        visualDensity: VisualDensity.adaptivePlatformDensity,
      ),
      home: HomeScreen(),
    );
  }
}

abstract class FakeDio {
  factory FakeDio([String options]) => Dio();

  void post();
}

class Dio implements FakeDio {
  @override
  void post() {
    //...
  }

}

FakeDio createDio([String options]) => throw UnsupportedError('');

class ApiHelper {
  static FakeDio get herokuApi {
    String options = "www.heroku.com/minhaApi/";

    return new FakeDio(options);
  }

  static FakeDio get awsApi {
    String options = "www.aws.com/minhaApi/";

    return new FakeDio(options);
  }
}

class FakeRemoteDataSource {
  final FakeDio herokuApi;
  final FakeDio awsApi;

  FakeRemoteDataSource({@required this.herokuApi, @required this.awsApi});

  Future<String> getNews() async {
    //herokuApi.post
    await Future.delayed(const Duration(seconds: 2));

    return "news";
  }

  Future<String> getProducts() async {
    //awsApi.post
    await Future.delayed(const Duration(seconds: 2));

    return "products";
  }
}
```